### PR TITLE
Fixed dependecy string

### DIFF
--- a/src/main/java/org/rbh/tfcadditions/Reference/Reference.java
+++ b/src/main/java/org/rbh/tfcadditions/Reference/Reference.java
@@ -10,7 +10,6 @@ public class Reference {
     public static final String ModVersion = "@MODVERSION@";
     public static final String TFCVersion = "@TFCVERSION@";
 
-    public static final String ModDependencies = "required-after:terrafirmacraft;required-after:CarpentersBlocks;required-after:NotEnoughItems";
     public static final String SERVER_PROXY_CLASS = "org.rbh.tfcadditions.Proxy.CommonProxy";
     public static final String CLIENT_PROXY_CLASS = "org.rbh.tfcadditions.Proxy.ClientProxy";
 

--- a/src/main/java/org/rbh/tfcadditions/TFCAdditions.java
+++ b/src/main/java/org/rbh/tfcadditions/TFCAdditions.java
@@ -13,10 +13,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
+ * Dependecies are specified in mcmod.info
  * Created by raymondbh on 15.07.2015.
  */
 
-@Mod(modid = Reference.ModID, name = Reference.ModName, version = Reference.ModVersion, dependencies = Reference.ModDependencies)
+@Mod(modid = Reference.ModID, name = Reference.ModName, version = Reference.ModVersion)
 public class TFCAdditions {
 
     public static final Logger LOG = LogManager.getLogger(Reference.ModID);

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -13,8 +13,8 @@
     "logoFile": "",
     "screenshots": [  ],
     "parent": "",
-    "requiredMods": [ "terrafirmacraft" ],
-    "dependencies": ["Forge@[10.13.4.1448,)"],
+    "requiredMods": [ "terrafirmacraft", "CarpentersBlocks", "NotEnoughItems" ],
+    "dependencies": ["Forge@[10.13.4.1448,)", "terrafirmacraft", "CarpentersBlocks", "NotEnoughItems"],
     "dependants": [  ],
     "useDependencyInformation": "true"
   }]


### PR DESCRIPTION
The will fix the load order. Aka this error

```
java.lang.NullPointerException: Initializing game
        at net.minecraft.item.ItemTool.<init>(ItemTool.java:29)
        at com.bioxx.tfc.Items.Tools.ItemTerraTool.<init>(ItemTerraTool.java:34)
        at org.rbh.tfcadditions.Items.Tools.ItemPlaner.<init>(ItemPlaner.java:25)
        at org.rbh.tfcadditions.Items.ItemSetup.LoadItems(ItemSetup.java:20)
```

You either have to specify `@Mod.useMetadata = false` and use `@Mod.dependencies = ...`
OR
Specify all dependencies in the mcmod.info file.

This is specified in the worst possible way in FML, I had to go digging in the Loader code to find this.
